### PR TITLE
chore(tauri): align config with schema v1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,6 @@
     "bundle": {
       "active": true,
       "identifier": "pro.popstas.windows-mqtt",
-      "mainBinaryName": "pro.popstas.windows-mqtt",
       "icon": [
         "../assets/trayicon.png"
       ],
@@ -27,7 +26,7 @@
       ],
       "windows": {
         "wix": {
-          "enable_elevated_update_task": false
+          "enableElevatedUpdateTask": false
         }
       }
     },
@@ -40,8 +39,7 @@
       }
     },
     "systemTray": {
-      "iconPath": "../assets/trayicon.png",
-      "id": "windows-mqtt-tray"
+      "iconPath": "../assets/trayicon.png"
     },
     "windows": [
       {


### PR DESCRIPTION
## Summary
- update Tauri bundle configuration to use schema-compliant keys
- remove unsupported system tray identifier entry

## Testing
- npx @tauri-apps/cli@1.6.0 dev *(fails: missing system glib-2.0 dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693775b6e794832c9f9f2d643cb234e3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Tauri config to schema v1 by renaming the Wix key and removing unsupported `mainBinaryName` and `systemTray.id`.
> 
> - **Tauri config (`src-tauri/tauri.conf.json`)**:
>   - **Bundle**:
>     - Remove `bundle.mainBinaryName`.
>     - Rename `windows.wix.enable_elevated_update_task` -> `windows.wix.enableElevatedUpdateTask`.
>   - **System Tray**:
>     - Remove unsupported `systemTray.id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9e17baf5d06e30f73808b0f86ac9e2a3bb402ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->